### PR TITLE
Add Electron wrapper app for Windows Cloud PC on Linux

### DIFF
--- a/windows-app/README.md
+++ b/windows-app/README.md
@@ -1,0 +1,42 @@
+# windows-app
+
+A minimal Electron desktop wrapper around Microsoft's Cloud PC portal:
+
+- https://windows.cloud.microsoft/
+
+This makes it behave like a standalone app window on Fedora/Linux.
+
+## Requirements
+
+- Node.js 20+
+- npm
+
+## Run
+
+```bash
+cd windows-app
+npm install
+npm start
+```
+
+## Optional: create a desktop launcher on Fedora
+
+Create `~/.local/share/applications/windows-cloud-app.desktop`:
+
+```ini
+[Desktop Entry]
+Name=Windows Cloud App
+Comment=Microsoft Windows 365 Cloud PC
+Exec=/usr/bin/env bash -lc 'cd /absolute/path/to/windows-app && npm start'
+Icon=computer
+Terminal=false
+Type=Application
+Categories=Network;RemoteAccess;
+StartupNotify=true
+```
+
+Then run:
+
+```bash
+update-desktop-database ~/.local/share/applications
+```

--- a/windows-app/main.js
+++ b/windows-app/main.js
@@ -1,0 +1,42 @@
+const { app, BrowserWindow, shell } = require('electron');
+
+const CLOUD_PC_URL = 'https://windows.cloud.microsoft/';
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1400,
+    height: 900,
+    minWidth: 1024,
+    minHeight: 700,
+    autoHideMenuBar: true,
+    backgroundColor: '#111827',
+    webPreferences: {
+      contextIsolation: true,
+      sandbox: true,
+      devTools: false
+    }
+  });
+
+  win.loadURL(CLOUD_PC_URL);
+
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    shell.openExternal(url);
+    return { action: 'deny' };
+  });
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/windows-app/package.json
+++ b/windows-app/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "windows-cloud-app",
+  "version": "1.0.0",
+  "description": "Electron wrapper for Windows 365 Cloud PC web client on Linux",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "keywords": [
+    "electron",
+    "windows-365",
+    "cloud-pc"
+  ],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "electron": "^37.0.0"
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight desktop-like wrapper so the Windows 365 Cloud PC web client (`https://windows.cloud.microsoft/`) can run as a standalone app window on Fedora/Linux. 
- Make opening the Cloud PC feel like a native app with controlled window sizing and external-link behavior.

### Description
- Add a new `windows-app` directory containing an Electron app scaffold with `main.js`, `package.json`, and `README.md`.
- Implement `main.js` to create a `BrowserWindow` that loads `https://windows.cloud.microsoft/`, sets sensible `width`/`height` and `minWidth`/`minHeight`, hides the menu bar, and sets `webPreferences` for isolation and sandboxing.
- Configure new-window/popup handling so external links are opened in the system browser via `shell.openExternal` instead of creating in-app windows.
- Add `package.json` with a `start` script (`npm start`) and an Electron devDependency, and include a `README.md` with run instructions and an optional Fedora `.desktop` launcher example.

### Testing
- Ran `node -v` in the environment and it returned a usable Node.js version (success).
- Ran `npm -v` in the environment and it returned a usable npm version (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7802928c8332b69599a458eb1630)