### PR TITLE
Add Electron wrapper app for Windows 365 Cloud PC (windows-app)

### DIFF
--- a/windows-app/README.md
+++ b/windows-app/README.md
@@ -1,0 +1,55 @@
+# windows-app
+
+A minimal Electron desktop wrapper around Microsoft's Cloud PC portal:
+
+- https://windows.cloud.microsoft/
+
+This behaves like a standalone app window on Fedora/Linux and includes a red app icon.
+
+## Included desktop assets
+
+- `windows-app-icon.svg` (red app icon)
+- `windows-cloud-app.desktop` (ready-to-copy launcher template that already references the icon)
+
+## Requirements
+
+- Node.js 20+
+- npm
+
+## Install
+
+```bash
+cd windows-app
+npm install
+```
+
+## Start
+
+```bash
+npm start
+```
+
+If the window appears to "hang" after launch on Linux, use:
+
+```bash
+npm run start:safe
+```
+
+For detailed logs:
+
+```bash
+npm run start:verbose
+```
+
+> `npm warn deprecated boolean@3.2.0` is a transitive dependency warning from Electron's dependency tree and does not prevent the app from launching.
+
+## Install the desktop launcher on Fedora
+
+1. Open `windows-cloud-app.desktop` and replace `/absolute/path/to/windows-app` with your real path.
+2. Copy it to your local applications folder:
+
+```bash
+cp windows-cloud-app.desktop ~/.local/share/applications/
+chmod +x ~/.local/share/applications/windows-cloud-app.desktop
+update-desktop-database ~/.local/share/applications
+```

--- a/windows-app/main.js
+++ b/windows-app/main.js
@@ -1,0 +1,58 @@
+const path = require('path');
+const { app, BrowserWindow, shell } = require('electron');
+
+const CLOUD_PC_URL = 'https://windows.cloud.microsoft/';
+const APP_ICON = path.join(__dirname, 'windows-app-icon.svg');
+
+app.commandLine.appendSwitch('enable-features', 'UseOzonePlatform');
+app.commandLine.appendSwitch('ozone-platform-hint', 'auto');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1400,
+    height: 900,
+    minWidth: 1024,
+    minHeight: 700,
+    autoHideMenuBar: true,
+    backgroundColor: '#7f1d1d',
+    icon: APP_ICON,
+    show: false,
+    webPreferences: {
+      contextIsolation: true,
+      sandbox: true,
+      devTools: true
+    }
+  });
+
+  win.once('ready-to-show', () => win.show());
+  win.loadURL(CLOUD_PC_URL);
+
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    shell.openExternal(url);
+    return { action: 'deny' };
+  });
+
+  win.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL) => {
+    console.error(`Failed to load ${validatedURL}: [${errorCode}] ${errorDescription}`);
+  });
+
+  win.webContents.on('render-process-gone', (_event, details) => {
+    console.error('Renderer process exited:', details);
+  });
+}
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/windows-app/package.json
+++ b/windows-app/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "windows-cloud-app",
+  "version": "1.0.1",
+  "description": "Electron wrapper for Windows 365 Cloud PC web client on Linux",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "start:safe": "electron . --disable-gpu --disable-software-rasterizer --enable-features=UseOzonePlatform --ozone-platform-hint=auto",
+    "start:verbose": "ELECTRON_ENABLE_LOGGING=1 ELECTRON_ENABLE_STACK_DUMPING=1 electron ."
+  },
+  "keywords": [
+    "electron",
+    "windows-365",
+    "cloud-pc"
+  ],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "electron": "^37.0.0"
+  }
+}

--- a/windows-app/windows-app-icon.svg
+++ b/windows-app/windows-app-icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="Windows Cloud App icon">
+  <rect width="256" height="256" rx="32" fill="#b91c1c"/>
+  <g fill="#ffffff">
+    <path d="M36 46.5 118 34v88H36z"/>
+    <path d="M132 32l88-13v103h-88z"/>
+    <path d="M36 130h82v88l-82-12.5z"/>
+    <path d="M132 130h88v106l-88-12.5z"/>
+  </g>
+</svg>

--- a/windows-app/windows-cloud-app.desktop
+++ b/windows-app/windows-cloud-app.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Name=Windows Cloud App
+Comment=Microsoft Windows 365 Cloud PC
+Exec=/usr/bin/env bash -lc 'cd /absolute/path/to/windows-app && npm start'
+Path=/absolute/path/to/windows-app
+Icon=/absolute/path/to/windows-app/windows-app-icon.svg
+Terminal=false
+Type=Application
+Categories=Network;RemoteAccess;
+StartupNotify=true


### PR DESCRIPTION
### Motivation

- Provide a minimal Electron desktop wrapper for the Microsoft Windows 365 Cloud PC web client to behave like a standalone app on Linux with a custom icon and launcher.

### Description

- Add a new `windows-app` directory containing an Electron `main.js` application that loads `https://windows.cloud.microsoft/`, forces external links to open in the system browser, logs load/render errors, and applies Ozone platform flags for Linux compatibility.
- Include `package.json` with `start`, `start:safe`, and `start:verbose` scripts and `electron` devDependency pinned to `^37.0.0`.
- Add desktop assets: `windows-app-icon.svg` (red icon) and a ready-to-copy `windows-cloud-app.desktop` launcher template, plus a `README.md` with install and run instructions.

### Testing

- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7802928c8332b69599a458eb1630)