### PR TITLE
Improve Windows app shortcut forwarding and browser compatibility

### DIFF
--- a/windows-app/README.md
+++ b/windows-app/README.md
@@ -32,6 +32,10 @@ Important platform limits on Linux:
 
 If registration fails, Electron logs a warning in the terminal.
 
+## Browser compatibility mode
+
+The app now sends an Edge-like user agent for all requests so Microsoft sign-in and Cloud PC checks treat the wrapper as a supported browser.
+
 ## Microsoft sign-in note
 
 If Microsoft sign-in endpoints appeared to receive `GET` instead of `POST`, that was caused by app-level navigation interception. The app now lets browser navigations proceed normally so auth POST flows are preserved.

--- a/windows-app/main.js
+++ b/windows-app/main.js
@@ -1,15 +1,24 @@
 const path = require('path');
-const { app, BrowserWindow, globalShortcut } = require('electron');
+const { app, BrowserWindow, globalShortcut, session } = require('electron');
 
 const CLOUD_PC_URL = 'https://windows.cloud.microsoft/';
 const APP_ICON = path.join(__dirname, 'windows-app-icon.svg');
+
+const EDGE_LIKE_USER_AGENT = [
+  'Mozilla/5.0 (X11; Linux x86_64)',
+  'AppleWebKit/537.36 (KHTML, like Gecko)',
+  'Chrome/136.0.0.0',
+  'Safari/537.36',
+  'Edg/136.0.0.0'
+].join(' ');
 
 app.commandLine.appendSwitch('enable-features', 'UseOzonePlatform');
 app.commandLine.appendSwitch('ozone-platform-hint', 'auto');
 
 const shortcutBindings = [
   { accelerator: 'CommandOrControl+V', keyCode: 'V', modifiers: ['control'] },
-  { accelerator: 'CommandOrControl+Shift+P', keyCode: 'P', modifiers: ['control', 'shift'] }
+  { accelerator: 'CommandOrControl+Shift+P', keyCode: 'P', modifiers: ['control', 'shift'] },
+  { accelerator: 'Super+V', keyCode: 'V', modifiers: ['meta'] }
 ];
 
 function sendShortcutToCloudPc(win, keyCode, modifiers) {
@@ -53,7 +62,8 @@ function createBaseWindowConfig() {
       contextIsolation: true,
       sandbox: true,
       devTools: true
-    }
+    },
+    userAgent: EDGE_LIKE_USER_AGENT
   };
 }
 
@@ -102,6 +112,11 @@ function createWindow() {
 }
 
 app.whenReady().then(() => {
+  session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
+    details.requestHeaders['User-Agent'] = EDGE_LIKE_USER_AGENT;
+    callback({ requestHeaders: details.requestHeaders });
+  });
+
   createWindow();
 
   app.on('activate', () => {


### PR DESCRIPTION
### Motivation
- Microsoft sign-in and Cloud PC were rejecting the Electron wrapper as an unsupported browser, breaking sign-in flows and ink checks. 
- The app should also attempt to forward Windows key combos (e.g. `Win+V`) into the remote session when the desktop environment allows it.

### Description
- Added an `EDGE_LIKE_USER_AGENT` constant and applied it to new windows via the `userAgent` BrowserWindow option in `createBaseWindowConfig()` to present an Edge-like UA to web endpoints (`windows-app/main.js`).
- Ensured all outgoing requests carry the Edge-like UA by hooking `session.defaultSession.webRequest.onBeforeSendHeaders` and setting the `User-Agent` header (`windows-app/main.js`).
- Added `Super+V` to `shortcutBindings` so the app attempts to forward `Win+V` (as `Super+V`) into the Cloud PC session using the existing global shortcut forwarding logic (`windows-app/main.js`).
- Documented the browser compatibility behavior in the README under a new `## Browser compatibility mode` section (`windows-app/README.md`).

### Testing
- Ran `node --check windows-app/main.js` to validate there are no basic syntax errors and it succeeded. 
- Verified repository status with `git -C /workspace/test status --short` which showed the two updated files. 
- Committed the changes with `git -C /workspace/test commit -m "Improve shortcut forwarding and browser compatibility"` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf876c2a083328131f6d8d5f7c248)