### PR TITLE
Harden Linux shortcut fallback and browser identity headers

### DIFF
--- a/windows-app/README.md
+++ b/windows-app/README.md
@@ -28,9 +28,14 @@ The app now uses Electron global shortcuts (while focused) to forward these keys
 Important platform limits on Linux:
 
 - `Alt+Tab` is controlled by your desktop environment/window manager and cannot be reliably hijacked by Electron.
-- `Win+V` (`Super+V`) is also typically reserved by the OS/desktop and may fail to register.
+- `Win+V` (`Super+V`) is typically reserved by GNOME Shell, so capture is best-effort only on Fedora GNOME/Wayland.
+- The app also registers `Alt+V` as a Linux fallback for clipboard-history style paste behavior when `Super+V` cannot be captured.
 
 If registration fails, Electron logs a warning in the terminal.
+
+## Browser compatibility mode
+
+The app now sends Edge-like Windows browser identity signals (`User-Agent`, user-agent metadata, and client-hint platform headers) so Microsoft sign-in and Cloud PC checks treat the wrapper as a supported browser.
 
 ## Microsoft sign-in note
 

--- a/windows-app/main.js
+++ b/windows-app/main.js
@@ -1,15 +1,39 @@
 const path = require('path');
-const { app, BrowserWindow, globalShortcut } = require('electron');
+const { app, BrowserWindow, globalShortcut, session } = require('electron');
 
 const CLOUD_PC_URL = 'https://windows.cloud.microsoft/';
 const APP_ICON = path.join(__dirname, 'windows-app-icon.svg');
+
+const EDGE_LIKE_USER_AGENT = [
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+  'AppleWebKit/537.36 (KHTML, like Gecko)',
+  'Chrome/136.0.0.0',
+  'Safari/537.36',
+  'Edg/136.0.0.0'
+].join(' ');
+
+const EDGE_LIKE_UA_METADATA = {
+  brands: [
+    { brand: 'Chromium', version: '136' },
+    { brand: 'Microsoft Edge', version: '136' },
+    { brand: 'Not=A?Brand', version: '99' }
+  ],
+  fullVersion: '136.0.0.0',
+  platform: 'Windows',
+  platformVersion: '10.0.0',
+  architecture: 'x86',
+  model: '',
+  mobile: false
+};
 
 app.commandLine.appendSwitch('enable-features', 'UseOzonePlatform');
 app.commandLine.appendSwitch('ozone-platform-hint', 'auto');
 
 const shortcutBindings = [
   { accelerator: 'CommandOrControl+V', keyCode: 'V', modifiers: ['control'] },
-  { accelerator: 'CommandOrControl+Shift+P', keyCode: 'P', modifiers: ['control', 'shift'] }
+  { accelerator: 'CommandOrControl+Shift+P', keyCode: 'P', modifiers: ['control', 'shift'] },
+  { accelerator: 'Super+V', keyCode: 'V', modifiers: ['meta'] },
+  { accelerator: 'Alt+V', keyCode: 'V', modifiers: ['alt'] }
 ];
 
 function sendShortcutToCloudPc(win, keyCode, modifiers) {
@@ -53,7 +77,8 @@ function createBaseWindowConfig() {
       contextIsolation: true,
       sandbox: true,
       devTools: true
-    }
+    },
+    userAgent: EDGE_LIKE_USER_AGENT
   };
 }
 
@@ -73,6 +98,8 @@ function createChildWindow(url) {
 }
 
 function attachWebContentsHandlers(win) {
+  win.webContents.setUserAgent(EDGE_LIKE_USER_AGENT, EDGE_LIKE_UA_METADATA);
+
   win.webContents.setWindowOpenHandler(({ url }) => {
     createChildWindow(url);
     return { action: 'deny' };
@@ -102,6 +129,13 @@ function createWindow() {
 }
 
 app.whenReady().then(() => {
+  session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
+    details.requestHeaders['User-Agent'] = EDGE_LIKE_USER_AGENT;
+    details.requestHeaders['Sec-CH-UA-Platform'] = '"Windows"';
+    details.requestHeaders['Sec-CH-UA-Mobile'] = '?0';
+    callback({ requestHeaders: details.requestHeaders });
+  });
+
   createWindow();
 
   app.on('activate', () => {


### PR DESCRIPTION
### Motivation
- `Super+V`/`Win+V` capture is unreliable on Fedora GNOME/Wayland so a best-effort fallback is needed for clipboard-history style paste forwarding. 
- Microsoft sign-in and Cloud PC checks inspect more than the UA string, so stronger Windows/Edge identity signals are required to avoid being treated as an unsupported browser.

### Description
- Change the Edge-like UA to a Windows token and apply it as the BrowserWindow `userAgent` via `createBaseWindowConfig()` in `windows-app/main.js`.
- Add `EDGE_LIKE_UA_METADATA` and call `win.webContents.setUserAgent(EDGE_LIKE_USER_AGENT, EDGE_LIKE_UA_METADATA)` so web-views expose user-agent metadata to pages.
- Inject client-hint headers (`Sec-CH-UA-Platform`, `Sec-CH-UA-Mobile`) and override `User-Agent` in `session.defaultSession.webRequest.onBeforeSendHeaders` for outgoing requests.
- Keep `Super+V` forwarding and add an `Alt+V` binding as a Linux fallback in `shortcutBindings`, and document GNOME/Wayland limitations plus the `Alt+V` fallback in `windows-app/README.md`.

### Testing
- Ran `node --check windows-app/main.js` to validate syntax; it succeeded.
- Verified repository state with `git status --short` and inspected changes with `git diff -- windows-app/main.js windows-app/README.md`; both succeeded.
- Committed the changes with `git commit` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf876c2a083328131f6d8d5f7c248)