### PR TITLE
Expand Edge client hints for Cloud PC browser detection

### DIFF
--- a/windows-app/README.md
+++ b/windows-app/README.md
@@ -28,9 +28,14 @@ The app now uses Electron global shortcuts (while focused) to forward these keys
 Important platform limits on Linux:
 
 - `Alt+Tab` is controlled by your desktop environment/window manager and cannot be reliably hijacked by Electron.
-- `Win+V` (`Super+V`) is also typically reserved by the OS/desktop and may fail to register.
+- `Win+V` (`Super+V`) is typically reserved by GNOME Shell, so capture is best-effort only on Fedora GNOME/Wayland.
+- The app also registers `Alt+V` as a Linux fallback for clipboard-history style paste behavior when `Super+V` cannot be captured.
 
 If registration fails, Electron logs a warning in the terminal.
+
+## Browser compatibility mode
+
+The app now sends Edge-like Windows browser identity signals (`User-Agent`, user-agent metadata, and client-hint platform headers) so Microsoft sign-in and Cloud PC checks treat the wrapper as a supported browser.
 
 ## Microsoft sign-in note
 

--- a/windows-app/main.js
+++ b/windows-app/main.js
@@ -1,15 +1,51 @@
 const path = require('path');
-const { app, BrowserWindow, globalShortcut } = require('electron');
+const { app, BrowserWindow, globalShortcut, session } = require('electron');
 
 const CLOUD_PC_URL = 'https://windows.cloud.microsoft/';
 const APP_ICON = path.join(__dirname, 'windows-app-icon.svg');
+
+const EDGE_LIKE_USER_AGENT = [
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64)',
+  'AppleWebKit/537.36 (KHTML, like Gecko)',
+  'Chrome/136.0.0.0',
+  'Safari/537.36',
+  'Edg/136.0.0.0'
+].join(' ');
+
+const EDGE_LIKE_UA_METADATA = {
+  brands: [
+    { brand: 'Chromium', version: '136' },
+    { brand: 'Microsoft Edge', version: '136' },
+    { brand: 'Not=A?Brand', version: '99' }
+  ],
+  fullVersion: '136.0.0.0',
+  platform: 'Windows',
+  platformVersion: '10.0.0',
+  architecture: 'x86',
+  model: '',
+  mobile: false
+};
+
+const EDGE_CLIENT_HINT_HEADERS = {
+  'Sec-CH-UA': '"Chromium";v="136", "Microsoft Edge";v="136", "Not=A?Brand";v="99"',
+  'Sec-CH-UA-Full-Version': '"136.0.0.0"',
+  'Sec-CH-UA-Full-Version-List': '"Chromium";v="136.0.0.0", "Microsoft Edge";v="136.0.0.0", "Not=A?Brand";v="99.0.0.0"',
+  'Sec-CH-UA-Mobile': '?0',
+  'Sec-CH-UA-Platform': '"Windows"',
+  'Sec-CH-UA-Platform-Version': '"10.0.0"',
+  'Sec-CH-UA-Arch': '"x86"',
+  'Sec-CH-UA-Model': '""',
+  'Sec-CH-UA-Bitness': '"64"'
+};
 
 app.commandLine.appendSwitch('enable-features', 'UseOzonePlatform');
 app.commandLine.appendSwitch('ozone-platform-hint', 'auto');
 
 const shortcutBindings = [
   { accelerator: 'CommandOrControl+V', keyCode: 'V', modifiers: ['control'] },
-  { accelerator: 'CommandOrControl+Shift+P', keyCode: 'P', modifiers: ['control', 'shift'] }
+  { accelerator: 'CommandOrControl+Shift+P', keyCode: 'P', modifiers: ['control', 'shift'] },
+  { accelerator: 'Super+V', keyCode: 'V', modifiers: ['meta'] },
+  { accelerator: 'Alt+V', keyCode: 'V', modifiers: ['alt'] }
 ];
 
 function sendShortcutToCloudPc(win, keyCode, modifiers) {
@@ -53,7 +89,8 @@ function createBaseWindowConfig() {
       contextIsolation: true,
       sandbox: true,
       devTools: true
-    }
+    },
+    userAgent: EDGE_LIKE_USER_AGENT
   };
 }
 
@@ -73,6 +110,8 @@ function createChildWindow(url) {
 }
 
 function attachWebContentsHandlers(win) {
+  win.webContents.setUserAgent(EDGE_LIKE_USER_AGENT, EDGE_LIKE_UA_METADATA);
+
   win.webContents.setWindowOpenHandler(({ url }) => {
     createChildWindow(url);
     return { action: 'deny' };
@@ -102,6 +141,20 @@ function createWindow() {
 }
 
 app.whenReady().then(() => {
+  session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
+    details.requestHeaders['User-Agent'] = EDGE_LIKE_USER_AGENT;
+
+    Object.entries(EDGE_CLIENT_HINT_HEADERS).forEach(([name, value]) => {
+      details.requestHeaders[name] = value;
+    });
+
+    if (!details.requestHeaders['Accept-Language']) {
+      details.requestHeaders['Accept-Language'] = 'en-US,en;q=0.9';
+    }
+
+    callback({ requestHeaders: details.requestHeaders });
+  });
+
   createWindow();
 
   app.on('activate', () => {


### PR DESCRIPTION
### Motivation
- Cloud PC continued to show an unsupported browser warning, indicating that spoofing the legacy `User-Agent` alone was insufficient for Microsoft’s browser capability checks.
- Those checks commonly read User-Agent Client Hints and related request metadata in addition to the legacy `User-Agent` header.

### Description
- Added a centralized `EDGE_CLIENT_HINT_HEADERS` constant in `windows-app/main.js` containing a fuller Edge/Chromium client-hint profile (multiple `Sec-CH-UA*` headers) and `Sec-CH-UA-Bitness`.
- Updated `session.defaultSession.webRequest.onBeforeSendHeaders` to apply the `EDGE_CLIENT_HINT_HEADERS` and to always set the legacy `User-Agent` on outgoing requests. 
- Added an `Accept-Language` fallback (`en-US,en;q=0.9`) when that header is not already present to better match a typical desktop Edge request profile.

### Testing
- Ran syntax validation with `node --check windows-app/main.js` and it passed.
- Reviewed the changes via `git diff -- windows-app/main.js` and verified the intended header additions were present.
- Committed the change as `Expand Edge client hints for Cloud PC browser detection` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf876c2a083328131f6d8d5f7c248)